### PR TITLE
fix: do no lock down dependency version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/trace-mapping": "0.3.25"
+        "@jridgewell/trace-mapping": "^0.3.25"
       },
       "devDependencies": {
         "@rollup/plugin-typescript": "11.1.6",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,6 @@
     "typescript": "5.3.3"
   },
   "dependencies": {
-    "@jridgewell/trace-mapping": "0.3.25"
+    "@jridgewell/trace-mapping": "^0.3.25"
   }
 }


### PR DESCRIPTION
Like https://github.com/jridgewell/trace-mapping/commit/57cdb5e751d8171b14106a739f459a5308455e5d